### PR TITLE
fixed perf and desync issues

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
 	"name":"Bottleneck",
 	"author":"Troels Bjerre Lund",
-	"version":"0.1.0",
+	"version":"0.0.4",
 	"factorio_version": "0.13",
 	"title":"Bottleneck",
 	"homepage":"https://github.com/troelsbjerre/Bottleneck",


### PR DESCRIPTION
Updates only 40 machines per tick. Causes some update latency (takes a moment for assemblers to update) but its better than slowing the game down.
Removed global.time thing that was causing desyncs in multiplayer.