### PR TITLE
Fixed version check in issue #4

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -13,8 +13,8 @@ function init()
 	-- Check if old version loaded
 	--]]
 	if (global.overlays ~= nil) then
-		if (global.version == nil) or (global.version ~= "0.2.4") then
-			global.version = "0.2.4"
+		if (global.version == nil) or (global.version ~= "0.2.6") then
+			global.version = "0.2.6"
 			for _, data in pairs(global.overlays) do
 				if data.signal then
 					data.signal.destroy()

--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
 	"name":"Bottleneck",
 	"author":"Troels Bjerre Lund",
-	"version":"0.2.4",
-	"factorio_version": "0.13",
+	"version":"0.2.6",
+	"factorio_version": "0.14",
 	"title":"Bottleneck",
 	"homepage":"https://github.com/troelsbjerre/Bottleneck",
 	"description":"A tool for locating input starved machines.",
-	"dependencies": ["base >= 0.13.0"]
+	"dependencies": ["base >= 0.14.0"]
 }


### PR DESCRIPTION
See issue #4
```
Fixed version check which required bumping to 0.2.6; and
Fixed info.json to reflect Factorio 0.14.
```

I didn't delete the `base` dependency, but I did update it to 0.14. If you check out the Factorio forums for the 0.14 release thread, the devs say that modders should not add a dependency against `base`.