### PR TITLE
Updates for 0.15

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -193,7 +193,7 @@ local function rebuild_overlays()
     for _, am in pairs(surface.find_entities_filtered{type="mining-drill"}) do
       built({created_entity = am})
     end
-    game.raise_event(events.rebuild_overlays, {})
+    script.raise_event(events.rebuild_overlays, {})
   end
 end
 
@@ -278,10 +278,10 @@ local function on_hotkey(event)
   end
   global.update_index = nil
   if global.show_bottlenecks == 1 then
-    game.raise_event(events.bottleneck_toggle, {tick=event.tick, player_index=event.player_index, enable=false})
+    script.raise_event(events.bottleneck_toggle, {tick=event.tick, player_index=event.player_index, enable=false})
     global.show_bottlenecks = -1
   else
-    game.raise_event(events.bottleneck_toggle, {tick=event.tick, player_index=event.player_index, enable=true})
+    script.raise_event(events.bottleneck_toggle, {tick=event.tick, player_index=event.player_index, enable=true})
     global.show_bottlenecks = 1
   end
 end

--- a/data.lua
+++ b/data.lua
@@ -15,7 +15,7 @@ Proto.empty_animation = {
   line_length = 1,
   frame_count = 1,
   shift = { 0, 0},
-  animation_speed = 0
+  animation_speed = 1
 }
 
 --off, green, red, yellow, blue
@@ -85,6 +85,7 @@ local stoplight = {
         shift = {-0.5, -0.3}
       },
     },
+    gas_flow = Proto.empty_animation,
     fluid_background = Proto.empty_sprite,
     window_background = Proto.empty_sprite,
     flow_sprite = Proto.empty_sprite,

--- a/info.json
+++ b/info.json
@@ -2,9 +2,9 @@
 	"name":"Bottleneck",
 	"author":"Troels Bjerre Lund",
 	"version":"0.6.2",
-	"factorio_version": "0.14",
+	"factorio_version": "0.15",
 	"title":"Bottleneck",
 	"homepage":"https://forums.factorio.com/viewtopic.php?f=144&t=28817",
 	"description":"A tool for locating input starved machines.",
-	"dependencies": ["base >= 0.14.0"]
+	"dependencies": ["base >= 0.15.0"]
 }


### PR DESCRIPTION
- game.raise_event was moved to script.raise_event
- storage-tank entity now requires a gas_flow property
- animation_speed property must be nil or >0, and nil seemed the most sensible for Proto.empty_animation

Haven't done a tremendous amount of testing, but this gets the mod working in 0.15