### PR TITLE
Factorio 0.16 bottleneck compatibility fix

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -25,8 +25,9 @@ end
 --https://forums.factorio.com/viewtopic.php?f=28&t=48100
 local function has_fluid_output_available(entity)
     local fluidbox = entity.fluidbox
-    if entity.recipe and fluidbox and #fluidbox > 0 then
-        for _, product in pairs(entity.recipe.products) do
+    local recipe = entity.get_recipe()
+    if recipe and fluidbox and #fluidbox > 0 then
+        for _, product in pairs(recipe.products) do
             if product.type == 'fluid' then
                 for i = 1, #fluidbox do
                     local fluid = fluidbox[i]

--- a/data.lua
+++ b/data.lua
@@ -26,6 +26,7 @@ local stoplight = {
     name = "bottleneck-stoplight",
     flags = {"not-blueprintable", "not-deconstructable", "not-on-map", "placeable-off-grid"},
     icon = "__Bottleneck__/graphics/red.png",
+    icon_size = 32,
     max_health = 100,
     selectable_in_game = false,
     mined_sound = nil,

--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
 	"name":"Bottleneck",
 	"author":"Troels Bjerre Lund",
-	"version":"0.8.5",
-	"factorio_version": "0.15",
+	"version":"0.9.0",
+	"factorio_version": "0.16",
 	"title":"Bottleneck",
 	"homepage":"https://forums.factorio.com/viewtopic.php?f=144&t=28817",
 	"description":"A tool for locating input starved machines.",
-	"dependencies": ["base >= 0.15.10"]
+	"dependencies": ["base >= 0.16.0"]
 }


### PR DESCRIPTION
Changes:
* replaced `recipe` property with `get_recipe()` function
* added missing `icon_size` property