### PR TITLE
Fixed broken has_fluid_output_available

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -31,7 +31,7 @@ local function has_fluid_output_available(entity)
             if product.type == 'fluid' then
                 for i = 1, #fluidbox do
                     local fluid = fluidbox[i]
-                    if fluid and (fluid.type == product.name) and (fluid.amount > 0) then
+                    if fluid and (fluid.name == product.name) and (fluid.amount > 0) then
                         return true
                     end
                 end


### PR DESCRIPTION
Fix for #40 was rather simple, the property name was changed and it just failed silently.

(0.16 API for fluidbox changed property name containing the "Fluid
prototype name" from "type" to "name")