### PR TITLE
Added a setting to limit the amount of updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Jetbrains stuff
+.idea
+*.iml
+
 # Compiled Lua sources
 luac.out
 

--- a/control.lua
+++ b/control.lua
@@ -225,7 +225,11 @@ local function rebuild_overlays()
     end
 end
 
-local function on_tick()
+local function on_tick(event)
+    if not (event.tick % settings.global["bottleneck-update-every-x-ticks"].value == 0) then
+        return
+    end
+
     local show_bottlenecks = global.show_bottlenecks
     if show_bottlenecks ~= 0 then
         local next = next --very slight perfomance improvment

--- a/locale/de/locale.cfg
+++ b/locale/de/locale.cfg
@@ -6,12 +6,14 @@ bottleneck-signals-per-tick=Signalupdates pro Tick:
 bottleneck-show-running-as=Stil für 'laufend':
 bottleneck-show-stopped-as=Stil für 'gestoppt':
 bottleneck-show-full-as=Stil für 'voll':
+bottleneck-update-every-x-ticks=Update alle x Ticks:
 
 [mode-setting-description]
 bottleneck-signals-per-tick=Wie viele Signal-Updates pro Tick durchgeführt werden. Je höher diese Zahl ist, desto größer ist der Einfluss auf die Performance.
 bottleneck-show-running-as=Mit welcher Farbe normal laufende Maschinen markiert werden sollen.
 bottleneck-show-stopped-as=Mit welcher Farbe gestoppte Maschinen markiert werden sollen. Dies sind Maschinen, die keine Rohstoffe mehr haben. 
 bottleneck-show-full-as=Mit welcher Farbe volle Maschinen markiert werden sollen. Dies sind Maschinen, die keinen Platz mehr für weitere Produkte haben. 
+bottleneck-update-every-x-ticks=Limitiere die Updatefrequenz für mehr Performance.
 
 [controls]
 bottleneck-hotkey=Bottleneck Lichter umschalten

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -6,12 +6,14 @@ bottleneck-signals-per-tick=Signals per tick:
 bottleneck-show-running-as=Style for running:
 bottleneck-show-stopped-as=Style for stopped:
 bottleneck-show-full-as=Style for full:
+bottleneck-update-every-x-ticks=Update every x ticks:
 
 [mode-setting-description]
 bottleneck-signals-per-tick=How many signals are processed per tick. The higher this number the bigger impact on performance.
 bottleneck-show-running-as=How should machines running normally be lit.
 bottleneck-show-stopped-as=How should stopped machines be lit. These are machines that have empty input trays.
 bottleneck-show-full-as=How should full machines be lit. These are machines that have full output trays.
+bottleneck-update-every-x-ticks=Limit the update rate to get better performance.
 
 [controls]
 bottleneck-hotkey=Toggle bottleneck lights

--- a/settings.lua
+++ b/settings.lua
@@ -1,35 +1,44 @@
-data:extend{
-    {
-        type = "int-setting",
-        name = "bottleneck-signals-per-tick",
-        setting_type = "runtime-global",
-        default_value = 40,
-        maximum_value = 2000,
-        minimum_value = 1,
-        order = "bottleneck-ac[signals-per-tick]"
-    },
+data:extend {
+	{
+		type = "int-setting",
+		name = "bottleneck-update-every-x-ticks",
+		setting_type = "runtime-global",
+		default_value = 10,
+		maximum_value = 2000,
+		minimum_value = 1,
+		order = "bottleneck-ac[update-every-x-ticks]"
+	},
+	{
+		type = "int-setting",
+		name = "bottleneck-signals-per-tick",
+		setting_type = "runtime-global",
+		default_value = 40,
+		maximum_value = 2000,
+		minimum_value = 1,
+		order = "bottleneck-ac[signals-per-tick]"
+	},
 	{
 		type = "string-setting",
 		name = "bottleneck-show-running-as",
 		setting_type = "runtime-global",
 		default_value = "green",
-		allowed_values = { "off", "green", "red", "yellow",	"blue",	"redx","yellowmin","offsmall","greensmall","redsmall","yellowsmall","bluesmall","redxsmall","yellowminsmall"}, 
-        order = "bottleneck-ad[show-running-as]"
+		allowed_values = { "off", "green", "red", "yellow", "blue", "redx", "yellowmin", "offsmall", "greensmall", "redsmall", "yellowsmall", "bluesmall", "redxsmall", "yellowminsmall" },
+		order = "bottleneck-ad[show-running-as]"
 	},
 	{
 		type = "string-setting",
 		name = "bottleneck-show-stopped-as",
 		setting_type = "runtime-global",
 		default_value = "red",
-		allowed_values = { "off", "green", "red", "yellow",	"blue",	"redx","yellowmin","offsmall","greensmall","redsmall","yellowsmall","bluesmall","redxsmall","yellowminsmall"}, 
-        order = "bottleneck-ae[show-stopped-as]"
+		allowed_values = { "off", "green", "red", "yellow", "blue", "redx", "yellowmin", "offsmall", "greensmall", "redsmall", "yellowsmall", "bluesmall", "redxsmall", "yellowminsmall" },
+		order = "bottleneck-ae[show-stopped-as]"
 	},
 	{
 		type = "string-setting",
 		name = "bottleneck-show-full-as",
 		setting_type = "runtime-global",
 		default_value = "yellow",
-		allowed_values = { "off", "green", "red", "yellow",	"blue",	"redx","yellowmin","offsmall","greensmall","redsmall","yellowsmall","bluesmall","redxsmall","yellowminsmall"}, 
-        order = "bottleneck-af[show-full-as]"
+		allowed_values = { "off", "green", "red", "yellow", "blue", "redx", "yellowmin", "offsmall", "greensmall", "redsmall", "yellowsmall", "bluesmall", "redxsmall", "yellowminsmall" },
+		order = "bottleneck-af[show-full-as]"
 	},
 }


### PR DESCRIPTION
This improves the performance a lot.
For example:
With a small map with science 1, 2 and military running Bottleneck needs
0.4ms to update.
If we use the new setting to update every 4 ticks 0.12ms. That's 70% less.
If we update just every 10 ticks we only need 0.06ms. That's 99,85%
less with no noticable impact. I still see the flickering of some
assemblers so I guess the update rate is still good enough.

This setting should mostly help bigger saves, but even for my small save
that is a significant gain.

EDIT: To clarify things a bit; with even this small save 2.5% of the maximum optimal tick/frame time are spent only in Bottleneck. If we use Bottleneck on a bigger save, I guess this number could go up to 10% and more. I try to update these numbers once my base get's bigger than just ~40 smelters and a bunch of assemblers and miners.