### PR TITLE
differentiate "full" and "blocked" machines

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -47,7 +47,7 @@ local LIGHT = {
 }
 
 local STATES = {
-    OFF = 1, RUNNING = 2, STOPPED = 3, FULL = 4,
+    OFF = 1, RUNNING = 2, STOPPED = 3, FULL = 4, BLOCKED = 5,
 }
 
 local STYLE = {
@@ -55,6 +55,7 @@ local STYLE = {
 	LIGHT[settings.global["bottleneck-show-running-as"].value],
 	LIGHT[settings.global["bottleneck-show-stopped-as"].value],
 	LIGHT[settings.global["bottleneck-show-full-as"].value],
+	LIGHT[settings.global["bottleneck-show-blocked-as"].value],
 }
 
 --Faster to just change the color than it is to check it first.
@@ -143,7 +144,9 @@ function update.machine(data)
         change_signal(data, STATES.STOPPED)
     elseif entity.is_crafting() and (entity.crafting_progress < 1) and (entity.bonus_progress < 1) then
         change_signal(data, STATES.RUNNING)
-    elseif (entity.crafting_progress >= 1) or (entity.bonus_progress >= 1) or (not entity.get_output_inventory().is_empty()) or (has_fluid_output_available(entity)) then
+    elseif (entity.crafting_progress >= 1) or (entity.bonus_progress >= 1) then
+        change_signal(data, STATES.BLOCKED)
+    elseif (not entity.get_output_inventory().is_empty()) or (has_fluid_output_available(entity)) then
         change_signal(data, STATES.FULL)
     else
         change_signal(data, STATES.STOPPED)
@@ -156,7 +159,9 @@ function update.furnace(data)
         change_signal(data, STATES.STOPPED)
     elseif entity.is_crafting() and (entity.crafting_progress < 1) and (entity.bonus_progress < 1) then
         change_signal(data, STATES.RUNNING)
-    elseif (entity.crafting_progress >= 1) or (entity.bonus_progress >= 1) or (not entity.get_output_inventory().is_empty()) or (has_fluid_output_available(entity)) then
+    elseif (entity.crafting_progress >= 1) or (entity.bonus_progress >= 1) then
+        change_signal(data, STATES.BLOCKED)
+    elseif (not entity.get_output_inventory().is_empty()) or (has_fluid_output_available(entity)) then
         change_signal(data, STATES.FULL)
     else
         change_signal(data, STATES.STOPPED)
@@ -288,6 +293,9 @@ local function update_settings(event)
 	end
 	if event.setting == "bottleneck-show-full-as" then
 		STYLE[STATES.FULL] = LIGHT[settings.global["bottleneck-show-full-as"].value]
+	end
+	if event.setting == "bottleneck-show-blocked-as" then
+		STYLE[STATES.BLOCKED] = LIGHT[settings.global["bottleneck-show-blocked-as"].value]
 	end
 end
 script.on_event(defines.events.on_runtime_mod_setting_changed, update_settings)

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -5,13 +5,15 @@ bottleneck-stoplight=Bottleneck signal light
 bottleneck-signals-per-tick=Signals per tick:
 bottleneck-show-running-as=Style for running:
 bottleneck-show-stopped-as=Style for stopped:
-bottleneck-show-full-as=Style for full:
+bottleneck-show-full-as=Style for filled:
+bottleneck-show-blocked-as=Style for blocked:
 
 [mode-setting-description]
 bottleneck-signals-per-tick=How many signals are processed per tick. The higher this number the bigger impact on performance.
 bottleneck-show-running-as=How should machines running normally be lit.
 bottleneck-show-stopped-as=How should stopped machines be lit. These are machines that have empty input trays.
-bottleneck-show-full-as=How should full machines be lit. These are machines that have full output trays.
+bottleneck-show-full-as=How should stopped machines be lit. These are machines that have full output trays.
+bottleneck-show-blocked-as=How should stopped machines be lit. These are machines that have full output trays and a completed crafting cycle blocked from moving to the output try.
 
 [controls]
 bottleneck-hotkey=Toggle bottleneck lights

--- a/settings.lua
+++ b/settings.lua
@@ -28,6 +28,14 @@ data:extend{
 		type = "string-setting",
 		name = "bottleneck-show-full-as",
 		setting_type = "runtime-global",
+		default_value = "redx",
+		allowed_values = { "off", "green", "red", "yellow",	"blue",	"redx","yellowmin","offsmall","greensmall","redsmall","yellowsmall","bluesmall","redxsmall","yellowminsmall"}, 
+        order = "bottleneck-af[show-full-as]"
+	},
+	{
+		type = "string-setting",
+		name = "bottleneck-show-blocked-as",
+		setting_type = "runtime-global",
 		default_value = "yellow",
 		allowed_values = { "off", "green", "red", "yellow",	"blue",	"redx","yellowmin","offsmall","greensmall","redsmall","yellowsmall","bluesmall","redxsmall","yellowminsmall"}, 
         order = "bottleneck-af[show-full-as]"


### PR DESCRIPTION
Note: This is my first time poking at Lua, and at Factorio modding, so other than intent, anything here can be wrong.

Previously all machines that were stopped and had *some* output waiting were counted as "full".

This meant machines that were lacking inputs but had some material still in the output tray, either sitting or being transferred out were given a yellow light instead of a red light.

This wasn't optimal, as "red" was easy to read as "materials missing", but when reading "yellow" as "the output is bottlenecking the machine" was sometimes correct and other times not.

After this change the "blocked" status is applied to machines that have a completed crafting cycle yet aren't working. This is marked with "yellow" and can be read with high confidence as "the output is bottlenecking the machine".

Stopped machines without a full crafting cycle are now marked as stopped or full separately, so one can still search for machines with stuff in them via the icon, but both are "red" now so it's easy as "bottlenecked due to missing inputs".