### PR TITLE
Add linting workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,11 @@
+on: push
+name: Check
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: lint
+        uses: Roang-zero1/factorio-mod-luacheck@master
+        env:
+          LUACHECKRC_URL: https://raw.githubusercontent.com/Nexela/Factorio-luacheckrc/0.17/.luacheckrc


### PR DESCRIPTION
I've created some GitHub workflows for Factorio Mods ([factorio-mod-actions](https://github.com/Roang-zero1/factorio-mod-actions)).
I would recommend to add the linting workflow in order to improve code quality (This pull request).

If there is any interest it is a also possible to do automatic releases from tagged versions of the repository to the mod portal and GitHub.
