### PR TITLE
Fix crash on initial machine build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.11.1 (2020-01-24)
+
+### Bugfixes
+
+- Fix crash on initial machine build
+
+---
+
 ## 0.11.0 (2020-01-24)
 
 ### Features
@@ -55,7 +63,7 @@
 
 ### Bugfixes
 
-- 0.16 compatibility fix by ochristi)
+- 0.16 compatibility fix by ochristi
 
 ### Other
 

--- a/changelog.json
+++ b/changelog.json
@@ -1,4 +1,10 @@
 {
+  "0.11.1": {
+    "date": "2020-01-24",
+    "Categories": {
+      "Bugfixes": ["Fix crash on initial machine build"]
+    }
+  },
   "0.11.0": {
     "date": "2020-01-24",
     "Categories": {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.11.1
+Date: 2020-01-24
+
+  Bugfixes:
+    - Fix crash on initial machine build
+---------------------------------------------------------------------------------------------------
 Version: 0.11.0
 Date: 2020-01-24
 
@@ -48,7 +54,7 @@ Version: 0.9.0
 Date: 2017-12-15
 
   Bugfixes:
-    - 0.16 compatibility fix by ochristi)
+    - 0.16 compatibility fix by ochristi
 
   Other:
     - Changed logic for state tracking, to avoid light flickering (some machines would show as yellow for a tick per cycle, even when working 100%)

--- a/control.lua
+++ b/control.lua
@@ -80,7 +80,7 @@ end
 
 local function new_signal(entity, variation)
     local signal = entity.surface.create_entity{name = "bottleneck-stoplight", position = get_signal_position_from(entity), force = entity.force}
-    signal.graphics_variation = (global.show_bottlenecks < 1 and LIGHT["off"]) or variation or STYLE[entity.status]
+    signal.graphics_variation = (global.show_bottlenecks < 1 and LIGHT["off"]) or variation or STYLE[entity.status] or LIGHT["off"]
     signal.destructible = false
     return signal
 end

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
   "name": "Bottleneck",
   "author": "Troels Bjerre Lund",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "factorio_version": "0.18",
   "title": "Bottleneck",
   "homepage": "https://forums.factorio.com/viewtopic.php?f=144&t=28817",


### PR DESCRIPTION
I've fixed a bug I introduced during the update where the mod will crash on initial machine build if the status is not found (will have to debug a bit more if this is an edgecase bug in the base game).