### PR TITLE
Add interface to manage blacklist from other mods

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -321,5 +321,14 @@ interface.change_signal = change_signal --function(data, color) change_signal(si
 interface.get_position_for_signal = get_signal_position_from
 --get the signal data associated with an entity
 interface.get_signal_data = function(unit_number) return global.overlays[unit_number] end
+interface.get_blacklist = function() return BLACKLIST_NAMES end
+interface.manage_blacklist = 
+   function(name, add) 
+    if (add) then 
+	  BLACKLIST_NAMES[name] = true
+	else
+	  BLACKLIST_NAMES[name] = nil
+	end
+   end	
 
 remote.add_interface("Bottleneck", interface)


### PR DESCRIPTION
I always had local patches to Bottleneck to have entity names not use Bottleneck
This PR allows to have it automated using 
```
local function onload()
  remote.call("Bottleneck","manage_blacklist","ultimate-transport-belt-beltbox",true)
end

script.on_load(onload)
```
