### PR TITLE
Disable signals on electric mining drills

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -51,7 +51,8 @@ local SUPPORTED_TYPES = {
 }
 
 local BLACKLIST_NAMES = {
-    ["factory-port-marker"] = true
+    ["electric-mining-drill"] = true,
+    ["factory-port-marker"] = true,
 }
 
 --Faster to just change the color than it is to check it first.


### PR DESCRIPTION
As of Factorio 0.18.31, the electric mining drill graphics include a status light, effectively rendering Bottleneck irrelevant for them.

Resolves #79