### PR TITLE
Add a blacklist_name remote interface

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -332,5 +332,7 @@ interface.change_signal = change_signal --function(data, color) change_signal(si
 interface.get_position_for_signal = get_signal_position_from
 --get the signal data associated with an entity
 interface.get_signal_data = function(unit_number) return global.overlays[unit_number] end
+--add an entity name to the list of ignored names
+interface.blacklist_name = function(entity_name) if(not BLACKLIST_NAMES[entity_name]) then BLACKLIST_NAMES[entity_name] = true; rebuild_overlays() end end
 
 remote.add_interface("Bottleneck", interface)


### PR DESCRIPTION
hi,

this pull allows mods to blacklist their entity(s) from bottleneck, here's an example of a working `control.lua`:

```
local function bottleneck()
    if remote.interfaces["Bottleneck"] and remote.interfaces["Bottleneck"]["blacklist_name"] then
        remote.call("Bottleneck", "blacklist_name", "liquify2-liquifier")
    end
end

script.on_init(bottleneck);
script.on_load(bottleneck);
```
(i would really love it if you could merge this or provide the required functionality somehow ❤️)